### PR TITLE
Removing implicit return in closures

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -337,14 +337,6 @@ UIView.animateWithDuration(1.0,
 }
 ```
 
-For single-expression closures where the context is clear, use implicit returns:
-
-```swift
-attendeeList.sort { a, b in
-    a > b
-}
-```
-
 
 ## Types
 


### PR DESCRIPTION
I prefer do not use implicit returns in single-line expressions in closures
